### PR TITLE
WF2: Fetch patient encounters

### DIFF
--- a/workflows/wf2/1-get-patients.js
+++ b/workflows/wf2/1-get-patients.js
@@ -13,9 +13,7 @@ fn(state => {
   return state;
 });
 
-searchPatient({ q: 'IQ', v: 'full', limit: '100' });
-//searchPatient({ q: 'MHtwo', v: 'full', limit: '3' });
-// searchPatient({ q: 'Patient', v: 'full', limit: '100' });
+searchPatient({ q: 'Katrina', v: 'full', limit: '100' });
 //Query all patients (q=all) not supported on demo OpenMRS; needs to be configured
 //...so we query all Patients with name "Patient" instead
 
@@ -25,7 +23,7 @@ fn(state => {
   const getPatientByUuid = uuid =>
     results.find(patient => patient.uuid === uuid).auditInfo.dateCreated;
 
-  // console.log('dateCreated for patient uuid ...2c6dbfc5acc8',getPatientByUuid("31b4d9c8-f7cc-4c26-ae61-2c6dbfc5acc8"))
+  //console.log('dateCreated for patient uuid ...2c6dbfc5acc8',getPatientByUuid("31b4d9c8-f7cc-4c26-ae61-2c6dbfc5acc8"))
   //console.log(JSON.stringify(state.data, null, 2));
 
   console.log('Filtering patients to only sync most recent records...');
@@ -37,8 +35,10 @@ fn(state => {
         : patient.auditInfo.dateChanged) > state.cursor
   );
   console.log('# of patients to sync to dhis2 ::', state.patients.length);
-  console.log('uuids of patients to sync to dhis2 ::', state.patients.map(p => p.uuid));
-  // console.log(JSON.stringify(patients, null, 2));
+  console.log(
+    'uuids of patients to sync to dhis2 ::',
+    state.patients.map(p => p.uuid)
+  );
 
   state.lastRunDateTime = new Date().toISOString();
   console.log('Updating cursor; next sync start date:', state.lastRunDateTime);

--- a/workflows/wf2/2-upsert-teis.js
+++ b/workflows/wf2/2-upsert-teis.js
@@ -242,5 +242,7 @@ fn(state => {
     response,
     ...next
   } = state;
+
+  next.patientUuids = patients.map(p => p.uuid);
   return next;
 });

--- a/workflows/wf2/3-get-encounters.js
+++ b/workflows/wf2/3-get-encounters.js
@@ -1,43 +1,55 @@
-// Fetch encounters from the date of cursor
-// OpenMRS demo instance does not support querying ALL records (q=all)
-// getEncounters({ q: 'Patient', v: 'full', limit: 100 });
-getEncounters({ q: 'Katrina', v: 'full' });
-
-// Update cursor and return encounters
 fn(state => {
-  const { cursor, data } = state;
-
-  console.log('cursor datetime::', cursor);
-  console.log('Filtering encounters to only get recent records...');
-  // console.log(
-  //   'Encounters returned before we filter for most recent ::',
-  //   JSON.stringify(encountersFound, null, 2)
-  // );
   state.formUuids = [
     '82db23a1-4eb1-3f3c-bb65-b7ebfe95b19b',
     '6a3e1e0e-dd13-3465-b8f5-ee2d42691fe5',
   ];
 
-  const encountersFound = state.formUuids.map(formUuid =>
-    data.results.filter(
-      encounter =>
-        encounter.encounterDatetime >= cursor && encounter.form.uuid == formUuid
-    )
-  );
+  console.log('cursor datetime::', state.cursor);
 
-  state.encounters = encountersFound
-    .map(encounters => encounters[0])
-    .filter(e => e);
+  return state;
+});
 
-  console.log(
-    '# of new encounters found in OMRS ::',
-    encountersFound.flat().length
-  );
+// Fetch patient encounters then filter by cursor date
+// OpenMRS demo instance does not support querying ALL records (q=all)
+each(
+  '$.patientUuids[*]',
+  getEncounters({ patient: $.data, v: 'full' }, state => {
+    const patientUuid = state.references.at(-1);
+    const filteredEncounters = state.formUuids.map(formUuid =>
+      state.data.results.filter(
+        encounter =>
+          encounter.encounterDatetime >= state.cursor &&
+          encounter.form.uuid == formUuid
+      )
+    );
 
-  console.log(
-    '# of new encounters to sync to dhis2 ::',
-    state.encounters.length
-  );
+    state.encounters ??= [];
+    state.encounters.push(
+      filteredEncounters.map(encounters => encounters[0]).filter(e => e)
+    );
 
-  return { ...state, data: {}, response: {}, references: [] };
+    console.log(
+      filteredEncounters.flat().length,
+      `# of filtered encounters found in OMRS for ${patientUuid}`
+    );
+
+    return state;
+  })
+);
+
+// Log filtered encounters
+fn(state => {
+  const {
+    encounters,
+    data,
+    response,
+    references,
+    index,
+    patientUuids,
+    ...next
+  } = state;
+  next.encounters = encounters.flat();
+  console.log(next.encounters.length, '# of new encounters to sync to dhis2');
+
+  return next;
 });


### PR DESCRIPTION
**Description**
For each patient uuid, fetch it's encounters 

**Notes**
- Updated the `get-patient` job to only return `Katrina` patient information
- Add an array of `patientUuids` in the final state of `upsert-teis`. These will be used in the `get-encounters` job
- For each patient `uuid` we fetch encounter then filter based on `cursor` and `form.uuid`

**Issue**
- #25 