### PR TITLE
Update `get-encounters` in `wf2-omrs-dhis2` to use openmrs adaptor

### DIFF
--- a/openfn-69066751-5f2c-459c-b42e-feba1c802383-spec.yaml
+++ b/openfn-69066751-5f2c-459c-b42e-feba1c802383-spec.yaml
@@ -53,7 +53,7 @@ workflows:
 
       Create-Patients:
         name: Create Patients
-        adaptor: '@openfn/language-openmrs@4.1.3'
+        adaptor: '@openfn/language-openmrs@4.2.0'
         credential: aissatou@openfn.org-MSF-OMRS-Demo-Nov-2024
         body:
           path: workflows/wf1/3-create-patients.js
@@ -100,7 +100,7 @@ workflows:
     jobs:
       Get-Patients:
         name: Get Patients
-        adaptor: '@openfn/language-openmrs@4.1.3'
+        adaptor: '@openfn/language-openmrs@4.2.0'
         credential: aleksa@openfn.org-MSF-OMRS-Demo---Raw-with-baseUrl
         body:
           path: workflows/wf2/1-get-patients.js
@@ -114,7 +114,7 @@ workflows:
 
       Get-Encounters:
         name: Get Encounters
-        adaptor: '@openfn/language-http@6.5.1'
+        adaptor: '@openfn/language-openmrs@4.2.0'
         credential: aleksa@openfn.org-MSF-OMRS-Demo---Raw-with-baseUrl
         body:
           path: workflows/wf2/3-get-encounters.js

--- a/workflows/wf2/2-mappings.js
+++ b/workflows/wf2/2-mappings.js
@@ -22248,8 +22248,8 @@ fn(state => {
         },
         optionSetMap: [
           { DNOavthBRGL: 'ec42d68d-3e23-43de-b8c5-a03bb538e7c7' },
-          { qr9jBtm9uvm: '24d1fa23-9778-4a8e-9f7b-93f694fc25e2' }, 
-          { FTbwlOo7CpG: 'e0b6ed99-72c4-4847-a442-e9929eac4a0f' }, 
+          { qr9jBtm9uvm: '24d1fa23-9778-4a8e-9f7b-93f694fc25e2' },
+          { FTbwlOo7CpG: 'e0b6ed99-72c4-4847-a442-e9929eac4a0f' },
           { y38Qm3uiuuV: 'a9b2c642-097f-43f8-b96b-4d2f50ffd9b1' },
           { G69FtaNkBgp: '3884dc76-c271-4bcb-8df8-81c6fb897f53' },
           { RpW3aZrlHDi: 'dd1f7f0f-ccea-4228-9aa8-a8c3b0ea4c3e' },

--- a/workflows/wf2/2-upsert-teis.js
+++ b/workflows/wf2/2-upsert-teis.js
@@ -32,7 +32,7 @@ const buildPatientsUpsert = (state, patient, isNewPatient) => {
     };
   });
 
-  const standardAttr =  [
+  const standardAttr = [
     {
       attribute: 'fa7uwpCKIwa',
       value: patient.person?.names[0]?.givenName,
@@ -44,10 +44,8 @@ const buildPatientsUpsert = (state, patient, isNewPatient) => {
     {
       attribute: 'P4wdYGkldeG', //DHIS2 ID ==> "Patient Number"
       value:
-        findIdentifierByUuid(
-          patient.identifiers,
-          state.dhis2PatientNumber
-        ) || findIdentifierByUuid(patient.identifiers, state.openmrsAutoId), //map OMRS ID if no DHIS2 id
+        findIdentifierByUuid(patient.identifiers, state.dhis2PatientNumber) ||
+        findIdentifierByUuid(patient.identifiers, state.openmrsAutoId), //map OMRS ID if no DHIS2 id
     },
     {
       attribute: 'ZBoxuExmxcZ', //MSF ID ==> "OpenMRS Patient Number"
@@ -72,12 +70,12 @@ const buildPatientsUpsert = (state, patient, isNewPatient) => {
     {
       attribute: 'rBtrjV1Mqkz', //Place of living
       value: placeOflivingMap[patient.person?.addresses[0]?.cityVillage],
-    }
+    },
   ];
 
   //filter out attributes that don't have a value from dhis2
-  const filteredAttr = standardAttr.filter(a => a.value)
-  const filteredStatusAttr = statusAttrMaps.filter(a => a.value)
+  const filteredAttr = standardAttr.filter(a => a.value);
+  const filteredStatusAttr = statusAttrMaps.filter(a => a.value);
   //console.log('standardAttr ::', JSON.stringify(standardAttr, null,2))
   //console.log('filteredAttr ::', JSON.stringify(filteredAttr, null,2))
 
@@ -91,10 +89,7 @@ const buildPatientsUpsert = (state, patient, isNewPatient) => {
       program: state.program,
       orgUnit: state.orgUnit,
       trackedEntityType: 'cHlzCA2MuEF',
-      attributes: [
-        ...filteredAttr,
-        ...filteredStatusAttr,
-      ],
+      attributes: [...filteredAttr, ...filteredStatusAttr],
     },
   };
 

--- a/workflows/wf2/workflow.json
+++ b/workflows/wf2/workflow.json
@@ -6,11 +6,20 @@
                 "adaptor": "openmrs",
                 "configuration": "../tmp/openmrs-creds.json",
                 "state": {
-                    "manualCursor": "2023-07-27T07:16:24.544Z"
+                    "lastRunDateTime": "2024-12-20T08:00:00.000Z"
                 },
                 "expression": "1-get-patients.js",
                 "next": {
-                    "upsert-teis": true
+                    "mappings": "!state.errors"
+                }
+            },
+            {
+                "id": "mappings",
+                "adaptor": "http",
+                "expression": "2-mappings.js",
+                "next": {
+                    "upsert-teis": "state.patients.length > 0 && !state.errors",
+                    "get-encounters": "!state.errors && state.patients.length === 0"
                 }
             },
             {
@@ -19,7 +28,7 @@
                 "configuration": "../tmp/dhis2-creds.json",
                 "expression": "2-upsert-teis.js",
                 "next": {
-                    "get-encounters": true
+                    "get-encounters": "state.patientUuids.length > 0 && !state.errors"
                 }
             },
             {
@@ -28,15 +37,7 @@
                 "configuration": "../tmp/openmrs-creds.json",
                 "expression": "3-get-encounters.js",
                 "next": {
-                    "get-options-map": true
-                }
-            },
-            {
-                "id": "get-options-map",
-                "adaptor": "http",
-                "expression": "4-get-options-map.js",
-                "next": {
-                    "get-teis": true
+                    "get-teis": "!state.errors && state.encounters"
                 }
             },
             {
@@ -45,14 +46,23 @@
                 "configuration": "../tmp/dhis2-creds.json",
                 "expression": "5-get-teis.js",
                 "next": {
-                    "create-events": true
+                    "create-events": "state.TEIs && !state.errors"
                 }
             },
             {
                 "id": "create-events",
                 "adaptor": "dhis2",
                 "configuration": "../tmp/dhis2-creds.json",
-                "expression": "6-create-events.js"
+                "expression": "6-create-events.js",
+                "next": {
+                    "update-teis": "state?.genderUpdated?.length > 0 && !state.errors"
+                }
+            },
+            {
+                "id": "update-teis",
+                "adaptor": "dhis2",
+                "configuration": "../tmp/dhis2-creds.json",
+                "expression": "7-update-teis.js"
             }
         ]
     }


### PR DESCRIPTION
**Summary**
Update `Get Encounters` step in `wf2-omrs-dhis2` workflow to use the latest `openmrs@4.2.0` adaptor instead of ~http6.*~ adaptor. Also update the [`69066751-5f2c-459c-b42e-feba1c802383 spec.yaml `] file to use the latest `openmrs@4.2.0` adaptor. I have also formatted the code for `2-mappings.js` and `2-upsert-teis.js`

**Fixes**
- #82 